### PR TITLE
make Kanban board scroll on mobile

### DIFF
--- a/src/Components/KanbanColumn.js
+++ b/src/Components/KanbanColumn.js
@@ -75,7 +75,7 @@ class KanbanColumn extends Component {
         const columnName = (isMobile && this.props.columnName === 'toDo') ? 'active' : '';
 
         return (
-            <div className={`col-12 col-md-4 ${isMobile} ${columnName}`}>
+            <div className={`col-md-4 column ${columnName}`}>
                 <div className="ibox">
                     <div className="ibox-content">
                         <h3>{nameMap[this.props.columnName]}</h3>

--- a/src/Containers/Kanban.js
+++ b/src/Containers/Kanban.js
@@ -117,23 +117,8 @@ class Kanban extends Component {
     render() {
         return (
             <DragDropContext onDragEnd={this.onDragEnd}>
-                <div 
-                    id="kanbanCarousel" 
-                    className="carousel slide" 
-                    data-ride="carousel" 
-                    data-wrap="false" 
-                    data-interval="false"
-                >
-                    <ol className="carousel-indicators">
-                        <li data-target="#kanbanCarousel" data-slide-to="0" className="active"></li>
-                        <li data-target="#kanbanCarousel" data-slide-to="1"></li>
-                        <li data-target="#kanbanCarousel" data-slide-to="2"></li>
-                    </ol>
-                    <div className="carousel-inner">
-                        <div className="row">
-                            {this.renderColumns()}
-                        </div>
-                    </div>
+                <div className="row kanban">
+                    {this.renderColumns()}
                 </div>
             </DragDropContext>
         );

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -37,9 +37,23 @@ body>*{
   border-radius: 50%;
   display: none;
 }
+.kanban{
+  background-color: #2f4050;
+  min-height: 100%;
+}
 @media (max-width: 600px) {
-  .carousel{
-    min-height: 100vh;
+  .row{
+    display: flex;
+    width: 300vw;
+    overflow: scroll;
+    flex-wrap: nowrap;
+    
+  }
+  .column{
+    min-width: 100vw;
+    padding-right: 0;
+    padding-left: 15px;
+    box-sizing: border-box;
   }
   .carousel-indicators{
     position: absolute;


### PR DESCRIPTION
**Description.**

This PR enables kanban board scroll on mobile

**How can this be manually tested**

Go to '/kanban' route on a mobile size screen and notice that the board scrolls horizontally